### PR TITLE
Added Server up/down embeddable badge to mimick build state.  Meant to be used with SiteMonitor

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/statusbadges/ImageResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/statusbadges/ImageResolver.java
@@ -9,6 +9,53 @@ import java.util.Locale;
 public class ImageResolver
 {
 
+    public StatusImage getServerImage( BallColor ballColor, String style)
+        throws IOException, FontFormatException
+    {
+        String subject = "server";
+        String status = "unknown";
+        String color;
+
+        if ( ballColor.isAnimated() )
+        {
+            status = "checking";
+        }
+        switch ( ballColor )
+        {
+            case RED:
+            case ABORTED:
+                status = "down";
+                // fall through
+            case RED_ANIME:
+            case ABORTED_ANIME:
+                color = "red";
+                break;
+            case YELLOW:
+                status = "unstable";
+                // fall through
+            case YELLOW_ANIME:
+                color = "yellow";
+                break;
+            case BLUE:
+                status = "up";
+                // fall through
+            case BLUE_ANIME:
+                color = "brightgreen";
+                break;
+            case DISABLED:
+            case DISABLED_ANIME:
+            case GREY:
+            case GREY_ANIME:
+            case NOTBUILT:
+            case NOTBUILT_ANIME:
+            default:
+                color = "lightgrey";
+                break;
+        }
+
+        return new StatusImage( subject, status, color, style );
+    }
+
     public StatusImage getBuildImage( BallColor ballColor, String style )
         throws IOException, FontFormatException
     {

--- a/src/main/java/org/jenkinsci/plugins/statusbadges/PublicServerAction.java
+++ b/src/main/java/org/jenkinsci/plugins/statusbadges/PublicServerAction.java
@@ -1,0 +1,59 @@
+package org.jenkinsci.plugins.statusbadges;
+
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.UnprotectedRootAction;
+import hudson.model.AbstractProject;
+import java.io.IOException;
+
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import java.awt.FontFormatException;
+
+/**
+ * Exposes the build status badge via unprotected URL. http://localhost:8080/statusbadges-build/icon?job=[JOBNAME]
+ */
+@Extension
+public class PublicServerAction
+    implements UnprotectedRootAction
+{
+    private final ImageResolver iconResolver;
+
+    private final BuildStatus buildStatus;
+
+    public PublicServerAction()
+    {
+        iconResolver = new ImageResolver();
+        buildStatus = new BuildStatus();
+    }
+
+    @Override
+    public String getUrlName()
+    {
+        return "statusbadges-server";
+    }
+
+    @Override
+    public String getIconFileName()
+    {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return null;
+    }
+
+    public HttpResponse doIcon( StaplerRequest req, StaplerResponse rsp, @QueryParameter String job,
+                                @QueryParameter String style )
+        throws IOException, FontFormatException
+    {
+        Job<?, ?> project = buildStatus.getProject( job, req, rsp );
+        return iconResolver.getServerImage( project.getIconColor(), style );
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/statusbadges/ServerAction.java
+++ b/src/main/java/org/jenkinsci/plugins/statusbadges/ServerAction.java
@@ -1,0 +1,49 @@
+package org.jenkinsci.plugins.statusbadges;
+
+import hudson.model.Action;
+import hudson.model.Job;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import java.awt.*;
+import java.io.IOException;
+
+public class ServerAction
+    implements Action
+{
+    private final ServerActionFactory factory;
+
+    public final Job<?, ?> project;
+
+    public ServerAction( ServerActionFactory factory, Job<?, ?> project )
+    {
+        this.factory = factory;
+        this.project = project;
+    }
+
+    @Override
+    public String getIconFileName()
+    {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return null;
+    }
+
+    @Override
+    public String getUrlName()
+    {
+        return "statusbadges-server";
+    }
+
+    public HttpResponse doIcon( StaplerRequest req, StaplerResponse rsp, @QueryParameter String style )
+        throws IOException, FontFormatException
+    {
+        return factory.getServerImage( project.getIconColor(), style );
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/statusbadges/ServerActionFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/statusbadges/ServerActionFactory.java
@@ -1,0 +1,37 @@
+package org.jenkinsci.plugins.statusbadges;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.BallColor;
+import hudson.model.Job;
+import jenkins.model.TransientActionFactory;
+
+import java.awt.*;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+@Extension
+public class ServerActionFactory extends TransientActionFactory<Job> {
+
+    private final ImageResolver iconResolver;
+
+    public ServerActionFactory() {
+        iconResolver = new ImageResolver();
+    }
+
+    @Override
+    public Class<Job> type() {
+        return Job.class;
+    }
+
+    @Override
+    public Collection<? extends Action> createFor( Job target ) {
+        return Collections.singleton( new ServerAction( this, target ) );
+    }
+
+    public StatusImage getServerImage( BallColor ballColor, String style ) throws IOException, FontFormatException {
+        return iconResolver.getServerImage( ballColor, style );
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/statusbadges/StatusAction/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/statusbadges/StatusAction/index.groovy
@@ -52,6 +52,8 @@ l.layout {
         def publicbadgeCoverage = "${app.rootUrl}statusbadges-coverage/icon?job=${fullJobName}";
         def badgeGrade = base + "statusbadges-grade/icon"
         def publicbadgeGrade = "${app.rootUrl}statusbadges-grade/icon?job=${fullJobName}";
+        def badgeServer = base + "statusbadges-server/icon"
+        def publicbadgeServer = "${app.rootUrl}statusbadges-server/icon?job=${fullJobName}";
 
         table(class:"codes") {
             thead {
@@ -96,6 +98,17 @@ l.layout {
                         input(type:"text",value:badgeCoverage,class:"select-all")
                         b {text(_("Unprotected"))}
                         input(type:"text",value:publicbadgeCoverage,class:"select-all")
+                    }
+                }
+                tr {
+                    td {
+                        img(src:publicbadgeServer)
+                    }
+                    td {
+                        b {text(_("Protected"))}
+                        input(type:"text",value:badgeServer,class:"select-all")
+                        b {text(_("Unprotected"))}
+                        input(type:"text",value:publicbadgeServer,class:"select-all")
                     }
                 }
             }


### PR DESCRIPTION
I created this because I needed an embeddable badge to reflect the up/down state of various sites.  The build step of the job is simply 'wget <url>'.  If the response code is 200, the site is up, else its down.  This is to be used in conjunction with SiteMonitor, but SiteMonitor doesn't provide a badge. 