### PR TITLE
Add Jacoco support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>3.0.3</version>
+    </dependency>
+    <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
       <version>3.2.2</version>
@@ -41,6 +46,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cobertura</artifactId>
       <version>1.9.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jacoco</artifactId>
+      <version>3.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>


### PR DESCRIPTION
This merge adds Jacoco support to the CoverageStatus badge.  
I've done the build and deployed the .hpi to our jenkins server.  For jobs with a jacoco report, it creates the badge correctly.  For jobs without, it creates the default 'coverage|unknown' badge.  

Support for cobertura and clover should remain intact, but I have no jobs using either of those to test with.  